### PR TITLE
記事の詳細ページを実装

### DIFF
--- a/app/javascript/app.vue
+++ b/app/javascript/app.vue
@@ -1,7 +1,7 @@
 <template>
   <v-app id="app">
     <dir class="header">
-     <Header/>
+      <Header/>
     </dir>
     <div class="layout">
       <router-view></router-view>

--- a/app/javascript/components/Article.vue
+++ b/app/javascript/components/Article.vue
@@ -1,0 +1,70 @@
+
+<template>
+  <v-container v-model="article" class="item elevation-3 article-container">
+    <v-layout xs-12 class="top-info-container">
+      <span class="user-name">@{{ article.user.name }}</span>
+      <time-ago :refresh="60" :datetime="article.updated_at" locale="en" tooltip="top" long></time-ago>
+    </v-layout>
+    <v-layout>
+      <h1 class="article-title">{{ article.title }}</h1>
+    </v-layout>
+    <v-layout class="article-body-container">
+      <div id="article-body">{{ article.body }}</div>
+    </v-layout>
+  </v-container>
+</template>
+
+<script>
+import axios from "axios";
+import TimeAgo from 'vue2-timeago'
+
+export default {
+  components: {
+    TimeAgo,
+  },
+
+  data() {
+    return {
+      article: ""
+    }
+  },
+
+  mounted() {
+    this.fetchArticle(this.$route.params.id)
+  },
+
+  methods: {
+    async fetchArticle(id) {
+      await axios
+        .get(`/api/v1/articles/${id}`)
+        .then(response => {
+          this.article = response.data;
+        })
+        .catch(e => {
+          // TODO: 適切な Error 表示
+          alert(e.response.statusText);
+        });
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.top-info-container {
+  margin-bottom: 1em;
+}
+.article-container {
+  margin: 2em;
+}
+.article-title {
+  font-size: 2.5em;
+  line-height: 1.4;
+}
+.article-body-container {
+  margin: 2em 0;
+  font-size: 16px;
+}
+.user-name {
+  margin-right: 1em;
+}
+</style>

--- a/app/javascript/components/ArticleList.vue
+++ b/app/javascript/components/ArticleList.vue
@@ -1,9 +1,11 @@
 <template>
   <v-container class="mt-5">
-    <div id="articles-container">
+    <div>
       <div v-for="article in articles" v-bind:key="article.id">
         <v-card flat class="mb-5 pb-7" style="margin: 0 auto;" justify-center max-width="600" >
-          <v-card-title>{{article.title}}</v-card-title>
+          <v-card-title class="article-title">
+            <router-link :to="{ name: 'article', params: { id: article.id }}">{{ article.title }}</router-link>
+          </v-card-title>
           <time-ago
             class="ml-5"
             :refresh="60"
@@ -48,3 +50,19 @@ export default {
   }
 }
 </script>
+
+<style lang="scss" scoped>
+.article-title {
+  a {
+    color: #000;
+    font-weight: bold;
+    text-decoration: none;
+  }
+  a:hover {
+    text-decoration: underline;
+  }
+  a:visited {
+    color: #777;
+  }
+}
+</style>

--- a/app/javascript/router/router.js
+++ b/app/javascript/router/router.js
@@ -1,6 +1,7 @@
 import Vue from "vue";
 import Router from "vue-router";
 import ArticleList from "../components/ArticleList.vue";
+import Article from "../components/Article.vue";
 import Registration from "../components/Registration.vue";
 import Login from "../components/Login.vue";
 import EditArticle from "../components/EditArticle.vue";
@@ -27,6 +28,10 @@ const router = new Router({
     {
       path: "/articles/new",
       component: EditArticle,
+    },
+    {
+      path: "/articles/:id",
+      component: Article,
     },
   ],
 });

--- a/app/javascript/router/router.js
+++ b/app/javascript/router/router.js
@@ -32,6 +32,7 @@ const router = new Router({
     {
       path: "/articles/:id",
       component: Article,
+      name: "article",
     },
   ],
 });

--- a/app/serializers/api/v1/article_serializer.rb
+++ b/app/serializers/api/v1/article_serializer.rb
@@ -1,4 +1,4 @@
 class Api::V1::ArticleSerializer < ActiveModel::Serializer
-  attributes :id, :title, :body
+  attributes :id, :title, :body, :updated_at
   belongs_to :user
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
   get "sign_up", to: "home#index"
   get "sign_in", to: "home#index"
   get "articles/new", to: "home#index"
+  get "articles/:id", to: "home#index"
 
   namespace :api do
     namespace :v1 do

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe "Api::V1::Articles", type: :request do
         expect(res["id"]).to eq article.id
         expect(res["title"]).to eq article.title
         expect(res["body"]).to eq article.body
+        expect(res["updated_at"]).to be_present
         expect(res["user"]["id"]).to eq article.user.id
         expect(res["user"].keys).to eq ["id", "name", "email"]
       end


### PR DESCRIPTION
## 概要
- 記事の詳細ページを作成
- 記事一覧に詳細ページへのリンクを設定

## イメージ
![記事詳細](https://user-images.githubusercontent.com/54180839/89149490-97190a00-d597-11ea-8ad0-dd760e241837.gif)
