### PR TITLE
Markdown を Syntax Highlight で表示する

### DIFF
--- a/app/javascript/app.vue
+++ b/app/javascript/app.vue
@@ -32,3 +32,20 @@ export default {
   background: #ECF6FE
 }
 </style>
+
+<style>
+.v-application code, .v-application kbd {
+  border-radius: initial !important;
+  font-size: initial !important;
+  font-weight: initial !important;
+}
+
+.hljs {
+  background-color: #23241f !important;
+  padding: 0.5em !important;
+}
+
+.hljs, .hljs-tag, .hljs-subst {
+    color: #fff !important;
+}
+</style>

--- a/app/javascript/components/Article.vue
+++ b/app/javascript/components/Article.vue
@@ -13,11 +13,11 @@
     </v-layout>
   </v-container>
 </template>
-
 <script>
 import axios from "axios";
 import TimeAgo from 'vue2-timeago'
 import marked from "marked";
+import hljs from 'highlight.js';
 
 export default {
   components: {
@@ -28,6 +28,36 @@ export default {
     return {
       article: ""
     }
+  },
+
+  async created(){
+    // Add 'hljs' class to code tag
+    const renderer = new marked.Renderer();
+    renderer.code = function(code, language) {
+      return (
+        "<pre" +
+        '><code class="hljs">' +
+        hljs.highlightAuto(code).value +
+        "</code></pre>"
+      );
+    };
+    marked.setOptions({
+      renderer: renderer,
+      tables: true,
+      sanitize: true,
+      langPrefix: "",
+      highlight: function(code, lang) {
+        if (!lang || lang == "default") {
+          return hljs.highlightAuto(code, [lang]).value;
+        } else {
+          try {
+            return hljs.highlight(lang, code, true).value;
+          } catch (e) {
+            // Do nonthing!
+          }
+        }
+      }
+    });
   },
 
   mounted() {
@@ -51,7 +81,7 @@ export default {
           // TODO: 適切な Error 表示
           alert(e.response.statusText);
         });
-    }
+    },
   }
 }
 </script>
@@ -61,7 +91,7 @@ export default {
   margin-bottom: 1em;
 }
 .article-container {
-  margin: 2em;
+  margin-top: 2em;
 }
 .article-title {
   font-size: 2.5em;

--- a/app/javascript/components/Article.vue
+++ b/app/javascript/components/Article.vue
@@ -9,7 +9,7 @@
       <h1 class="article-title">{{ article.title }}</h1>
     </v-layout>
     <v-layout class="article-body-container">
-      <div id="article-body">{{ article.body }}</div>
+      <div id="article-body" v-html="compiledMarkdown"></div>
     </v-layout>
   </v-container>
 </template>
@@ -17,6 +17,7 @@
 <script>
 import axios from "axios";
 import TimeAgo from 'vue2-timeago'
+import marked from "marked";
 
 export default {
   components: {
@@ -31,6 +32,12 @@ export default {
 
   mounted() {
     this.fetchArticle(this.$route.params.id)
+  },
+
+  computed: {
+    compiledMarkdown() {
+      return marked(this.article.body);
+    }
   },
 
   methods: {

--- a/app/javascript/packs/hello_vue.js
+++ b/app/javascript/packs/hello_vue.js
@@ -14,6 +14,7 @@ import App from "../app.vue";
 import axios from "axios";
 import VueAxios from "vue-axios";
 import "vuetify/dist/vuetify.min.css";
+import "highlight.js/styles/monokai.css";
 import Vuetify from "vuetify";
 Vue.use(Vuex);
 Vue.use(VueRouter);

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@rails/ujs": "^6.0.0",
     "@rails/webpacker": "4.2.2",
     "axios": "^0.19.2",
+    "highlight.js": "^10.1.2",
     "marked": "^1.1.1",
     "turbolinks": "^5.2.0",
     "vue": "^2.6.11",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@rails/ujs": "^6.0.0",
     "@rails/webpacker": "4.2.2",
     "axios": "^0.19.2",
+    "marked": "^1.1.1",
     "turbolinks": "^5.2.0",
     "vue": "^2.6.11",
     "vue-axios": "^2.1.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4991,6 +4991,11 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
+marked@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-1.1.1.tgz#e5d61b69842210d5df57b05856e0c91572703e6a"
+  integrity sha512-mJzT8D2yPxoPh7h0UXkB+dBj4FykPJ2OIfxAWeIHrvoHDkFxukV/29QxoFQoPM6RLEwhIFdJpmKBlqVM3s2ZIw==
+
 md5.js@^1.3.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/md5.js/-/md5.js-1.3.5.tgz#b5d07b8e3216e3e27cd728d72f70d1e6a342005f"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4107,6 +4107,11 @@ hex-color-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"
   integrity sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==
 
+highlight.js@^10.1.2:
+  version "10.1.2"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.1.2.tgz#c20db951ba1c22c055010648dfffd7b2a968e00c"
+  integrity sha512-Q39v/Mn5mfBlMff9r+zzA+gWxRsCRKwEMvYTiisLr/XUiFI/4puWt0Ojdko3R3JCNWGdOWaA5g/Yxqa23kC5AA==
+
 hmac-drbg@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"


### PR DESCRIPTION
## 概要
- テキスト本文を確認する際、Markdown を Syntax highlight して表示するように調整

## イメージ
<img width="1087" alt="スクリーンショット 2020-08-10 1 54 57" src="https://user-images.githubusercontent.com/54180839/89737575-d28e6980-daac-11ea-903f-680feeec054d.png">
