### PR TITLE
記事の下書き機能を実装

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -3,12 +3,12 @@ module Api::V1
     before_action :authenticate_user!, only: [:create, :update, :destroy]
 
     def index
-      articles = Article.order(updated_at: :desc)
+      articles = Article.published.order(updated_at: :desc)
       render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer
     end
 
     def show
-      article = Article.find(params[:id])
+      article = Article.published.find(params[:id])
       render json: article
     end
 
@@ -20,6 +20,7 @@ module Api::V1
     def update
       article = current_user.articles.find(params[:id])
       article.update!(article_params)
+      render json: article
     end
 
     def destroy
@@ -30,7 +31,7 @@ module Api::V1
     private
 
       def article_params
-        params.require(:article).permit(:title, :body)
+        params.require(:article).permit(:title, :body, :status)
       end
   end
 end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -4,6 +4,7 @@
 #
 #  id         :bigint           not null, primary key
 #  body       :text
+#  status     :string           default("draft")
 #  title      :string
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
@@ -17,4 +18,6 @@ class Article < ApplicationRecord
   belongs_to :user
   has_many :comments, dependent: :destroy
   has_many :article_likes, dependent: :destroy
+
+  enum status: { draft: "draft", published: "published" }
 end

--- a/app/serializers/api/v1/article_serializer.rb
+++ b/app/serializers/api/v1/article_serializer.rb
@@ -1,4 +1,4 @@
 class Api::V1::ArticleSerializer < ActiveModel::Serializer
-  attributes :id, :title, :body, :updated_at
+  attributes :id, :title, :body, :status, :updated_at
   belongs_to :user
 end

--- a/db/migrate/20200810080657_add_status_to_articles.rb
+++ b/db/migrate/20200810080657_add_status_to_articles.rb
@@ -1,0 +1,5 @@
+class AddStatusToArticles < ActiveRecord::Migration[6.0]
+  def change
+    add_column :articles, :status, :string, default: "draft"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_02_125252) do
+ActiveRecord::Schema.define(version: 2020_08_10_080657) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -30,6 +30,7 @@ ActiveRecord::Schema.define(version: 2020_07_02_125252) do
     t.bigint "user_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "status", default: "draft"
     t.index ["user_id"], name: "index_articles_on_user_id"
   end
 

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -4,6 +4,7 @@
 #
 #  id         :bigint           not null, primary key
 #  body       :text
+#  status     :string           default("draft")
 #  title      :string
 #  created_at :datetime         not null
 #  updated_at :datetime         not null

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -18,6 +18,15 @@ FactoryBot.define do
   factory :article do
     title { Faker::Lorem.word }
     body { Faker::Lorem.sentence }
+    status { :published }
     user
+
+    trait :draft do
+      status { :draft }
+    end
+
+    trait :published do
+      status { :published }
+    end
   end
 end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -4,6 +4,7 @@
 #
 #  id         :bigint           not null, primary key
 #  body       :text
+#  status     :string           default("draft")
 #  title      :string
 #  created_at :datetime         not null
 #  updated_at :datetime         not null

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -4,11 +4,13 @@ RSpec.describe "Api::V1::Articles", type: :request do
   describe "GET /articles" do
     subject { get(api_v1_articles_path) }
 
-    let!(:article1) { create(:article, updated_at: 1.days.ago) }
-    let!(:article2) { create(:article, updated_at: 2.days.ago) }
-    let!(:article3) { create(:article) }
+    let!(:article1) { create(:article, :published, updated_at: 1.days.ago) }
+    let!(:article2) { create(:article, :published, updated_at: 2.days.ago) }
+    let!(:article3) { create(:article, :published) }
 
-    it "記事の一覧が取得できる" do
+    before { create(:article, :draft) }
+
+    it "公開済みの記事の一覧が取得できる(更新順)" do
       subject
       res = JSON.parse(response.body)
 
@@ -23,21 +25,32 @@ RSpec.describe "Api::V1::Articles", type: :request do
   describe "GET /users/:id" do
     subject { get(api_v1_article_path(article_id)) }
 
-    context "指定した id の記事が存在する場合" do
-      let(:article) { create(:article) }
+    context "指定した id の記事が存在して" do
       let(:article_id) { article.id }
 
-      it "任意の記事が取得できる" do
-        subject
-        res = JSON.parse(response.body)
+      context "対象の記事が公開中であるとき" do
+        let(:article) { create(:article, :published) }
 
-        expect(response).to have_http_status(:ok)
-        expect(res["id"]).to eq article.id
-        expect(res["title"]).to eq article.title
-        expect(res["body"]).to eq article.body
-        expect(res["updated_at"]).to be_present
-        expect(res["user"]["id"]).to eq article.user.id
-        expect(res["user"].keys).to eq ["id", "name", "email"]
+        it "任意の記事が取得できる" do
+          subject
+          res = JSON.parse(response.body)
+
+          expect(response).to have_http_status(:ok)
+          expect(res["id"]).to eq article.id
+          expect(res["title"]).to eq article.title
+          expect(res["body"]).to eq article.body
+          expect(res["updated_at"]).to be_present
+          expect(res["user"]["id"]).to eq article.user.id
+          expect(res["user"].keys).to eq ["id", "name", "email"]
+        end
+      end
+
+      context "対象の記事が下書き状態であるとき" do
+        let(:article) { create(:article, :draft) }
+
+        it "記事が見つからない" do
+          expect { subject }.to raise_error ActiveRecord::RecordNotFound
+        end
       end
     end
 
@@ -53,32 +66,56 @@ RSpec.describe "Api::V1::Articles", type: :request do
   describe "POST /articles" do
     subject { post(api_v1_articles_path, params: params, headers: headers) }
 
-    let(:params) { { article: attributes_for(:article) } }
     let(:current_user) { create(:user) }
     let(:headers) { current_user.create_new_auth_token }
 
-    it "記事のレコードが作成できる" do
-      expect { subject }.to change { Article.where(user_id: current_user.id).count }.by(1)
-      res = JSON.parse(response.body)
-      expect(res["title"]).to eq params[:article][:title]
-      expect(res["body"]).to eq params[:article][:body]
-      expect(response).to have_http_status(:ok)
+    context "公開指定で記事を作成するとき" do
+      let(:params) { { article: attributes_for(:article, :published) } }
+
+      it "記事のレコードが作成できる" do
+        expect { subject }.to change { Article.where(user_id: current_user.id).count }.by(1)
+        res = JSON.parse(response.body)
+        expect(res["title"]).to eq params[:article][:title]
+        expect(res["body"]).to eq params[:article][:body]
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "下書き指定で記事を作成するとき" do
+      let(:params) { { article: attributes_for(:article, :draft) } }
+
+      it "下書き記事が作成できる" do
+        expect { subject }.to change { Article.count }.by(1)
+        res = JSON.parse(response.body)
+        expect(res["status"]).to eq "draft"
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "でたらめな指定で記事を作成するとき" do
+      let(:params) { { article: attributes_for(:article, status: :foo) } }
+
+      it "エラーになる" do
+        expect { subject }.to raise_error(ArgumentError)
+      end
     end
   end
 
   describe "PATCH /api/v1/articles/:id" do
     subject { patch(api_v1_article_path(article.id), params: params, headers: headers) }
 
-    let(:params) { { article: attributes_for(:article) } }
+    let(:params) { { article: attributes_for(:article, :published) } }
     let(:current_user) { create(:user) }
     let(:headers) { current_user.create_new_auth_token }
 
     context "自分の記事を更新するとき" do
-      let(:article) { create(:article, user: current_user) }
+      let!(:article) { create(:article, :draft, user: current_user) }
 
       it "任意の記事の更新ができる" do
-        expect { subject }.to change { Article.find(article.id).title }.from(article.title).to(params[:article][:title]) &
-                              change { Article.find(article.id).body }.from(article.body).to(params[:article][:body])
+        expect { subject }.to change { article.reload.title }.from(article.title).to(params[:article][:title]) &
+                              change { article.reload.body }.from(article.body).to(params[:article][:body]) &
+                              change { article.reload.status }.from(article.status).to(params[:article][:status].to_s)
+        expect(response).to have_http_status(:ok)
       end
     end
 


### PR DESCRIPTION
## 概要
- 記事の下書き機能を実装
  - 一覧には下書き記事は表示されない
  - 記事の詳細は記事の所持者にかかわらず、公開された状態にならないと閲覧できない
  - 作成 / 更新時に記事公開のステータスを任意の値に変更できるように調整

