### PR TITLE
記事に関する model のテストを追加

### DIFF
--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -18,7 +18,6 @@ FactoryBot.define do
   factory :article do
     title { Faker::Lorem.word }
     body { Faker::Lorem.sentence }
-    status { :published }
     user
 
     trait :draft do

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -17,5 +17,30 @@
 require "rails_helper"
 
 RSpec.describe Article, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe "正常系" do
+    context "タイトルと本文が入力されているとき" do
+      let(:article) { build(:article) }
+
+      it "下書き状態の記事が作成できる" do
+        expect(article).to be_valid
+        expect(article.status).to eq "draft"
+      end
+    end
+
+    context "status が下書き状態のとき" do
+      let(:article) { build(:article, :draft) }
+      it "記事を下書き状態で作成できる" do
+        expect(article).to be_valid
+        expect(article.status).to eq "draft"
+      end
+    end
+
+    context "status が公開状態のとき" do
+      let(:article) { build(:article, :published) }
+      it "記事を公開状態で作成できる" do
+        expect(article).to be_valid
+        expect(article.status).to eq "published"
+      end
+    end
+  end
 end


### PR DESCRIPTION
## 概要
- model のテストを忘れていたので実装

## 内容
- モデルの default による設定で status を指定しない場合は状態が draft になる。
そのため Factory のカラムに status を指定していたがテストの際に default の挙動チェックができないため削除した。