### PR TITLE
Task. 11-3 下書き記事の一覧/詳細 のAPI実装

### DIFF
--- a/app/controllers/api/v1/articles/drafts_controller.rb
+++ b/app/controllers/api/v1/articles/drafts_controller.rb
@@ -1,0 +1,10 @@
+module Api::V1
+  class Articles::DraftsController < BaseApiController
+    before_action :authenticate_user!, only: [:index]
+
+    def index
+      articles = current_user.articles.draft.order(updated_at: :desc)
+      render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer
+    end
+  end
+end

--- a/app/controllers/api/v1/articles/drafts_controller.rb
+++ b/app/controllers/api/v1/articles/drafts_controller.rb
@@ -1,10 +1,15 @@
 module Api::V1
   class Articles::DraftsController < BaseApiController
-    before_action :authenticate_user!, only: [:index]
+    before_action :authenticate_user!, only: [:index, :show]
 
     def index
       articles = current_user.articles.draft.order(updated_at: :desc)
       render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer
+    end
+
+    def show
+      article = current_user.articles.draft.find(params[:id])
+      render json: article, serializer: Api::V1::ArticleSerializer
     end
   end
 end

--- a/app/serializers/api/v1/article_preview_serializer.rb
+++ b/app/serializers/api/v1/article_preview_serializer.rb
@@ -1,4 +1,4 @@
 class Api::V1::ArticlePreviewSerializer < ActiveModel::Serializer
   attributes :id, :title, :updated_at
-  belongs_to :user
+  belongs_to :user, serializer: Api::V1::UserSerializer
 end

--- a/app/serializers/api/v1/article_serializer.rb
+++ b/app/serializers/api/v1/article_serializer.rb
@@ -1,4 +1,4 @@
 class Api::V1::ArticleSerializer < ActiveModel::Serializer
   attributes :id, :title, :body, :status, :updated_at
-  belongs_to :user
+  belongs_to :user, serializer: Api::V1::UserSerializer
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,7 @@ Rails.application.routes.draw do
         registrations: "api/v1/auth/registrations",
       }
       namespace :articles do
-        resources :drafts, only: [:index]
+        resources :drafts, only: [:index, :show]
       end
       resources :articles
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,9 @@ Rails.application.routes.draw do
       mount_devise_token_auth_for "User", at: "auth", controllers: {
         registrations: "api/v1/auth/registrations",
       }
+      namespace :articles do
+        resources :drafts, only: [:index]
+      end
       resources :articles
     end
   end

--- a/spec/requests/api/v1/articles/drafts_spec.rb
+++ b/spec/requests/api/v1/articles/drafts_spec.rb
@@ -1,11 +1,11 @@
 require "rails_helper"
 
 RSpec.describe "Api::V1::Articles::Drafts", type: :request do
+  let(:current_user) { create(:user) }
+  let(:headers) { current_user.create_new_auth_token }
+
   describe "GET /api/v1/articles/drafts" do
     subject { get(api_v1_articles_drafts_path, headers: headers) }
-
-    let(:current_user) { create(:user) }
-    let(:headers) { current_user.create_new_auth_token }
 
     context "自分の書いた下書きの記事が存在するとき" do
       let!(:article1) { create(:article, :draft, user: current_user) }
@@ -19,6 +19,40 @@ RSpec.describe "Api::V1::Articles::Drafts", type: :request do
         expect(res.length).to eq 1
         expect(res[0].keys).to eq ["id", "title", "updated_at", "user"]
         expect(res[0]["user"].keys).to eq ["id", "name", "email"]
+      end
+    end
+  end
+
+  describe "GET /articles/drafts/:id" do
+    subject { get(api_v1_articles_draft_path(article_id), headers: headers) }
+
+    context "指定した id の記事が存在して" do
+      let(:article_id) { article.id }
+
+      context "対象の記事が自分が書いた下書きのとき" do
+        let(:article) { create(:article, :draft, user: current_user) }
+
+        it "記事の詳細を取得できる" do
+          subject
+          res = JSON.parse(response.body)
+
+          expect(response).to have_http_status(:ok)
+          expect(res["id"]).to eq article.id
+          expect(res["title"]).to eq article.title
+          expect(res["body"]).to eq article.body
+          expect(res["status"]).to eq article.status
+          expect(res["updated_at"]).to be_present
+          expect(res["user"]["id"]).to eq article.user.id
+          expect(res["user"].keys).to eq ["id", "name", "email"]
+        end
+      end
+
+      context "対象の記事が他のユーザーが書いた下書きのとき" do
+        let(:article) { create(:article, :draft) }
+
+        it "記事が見つからない" do
+          expect { subject }.to raise_error ActiveRecord::RecordNotFound
+        end
       end
     end
   end

--- a/spec/requests/api/v1/articles/drafts_spec.rb
+++ b/spec/requests/api/v1/articles/drafts_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Articles::Drafts", type: :request do
+  describe "GET /api/v1/articles/drafts" do
+    subject { get(api_v1_articles_drafts_path, headers: headers) }
+
+    let(:current_user) { create(:user) }
+    let(:headers) { current_user.create_new_auth_token }
+
+    context "自分の書いた下書きの記事が存在するとき" do
+      let!(:article1) { create(:article, :draft, user: current_user) }
+      let!(:article2) { create(:article, :draft) }
+
+      it "自分が書いた下書き記事の一覧のみが取得できる" do
+        subject
+        res = JSON.parse(response.body)
+
+        expect(response).to have_http_status(:ok)
+        expect(res.length).to eq 1
+        expect(res[0].keys).to eq ["id", "title", "updated_at", "user"]
+        expect(res[0]["user"].keys).to eq ["id", "name", "email"]
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要
- 下書きに関する記事の一覧・詳細を取得する API を実装
- 実装に必要な各 serializer を調整