### PR TITLE
記事の編集、削除機能をフロントに紐付け

### DIFF
--- a/app/javascript/components/Article.vue
+++ b/app/javascript/components/Article.vue
@@ -8,7 +8,7 @@
         <v-btn text fab small class="mr-5" @click="moveToEditArticlePage(article.id)">
           <v-icon color="#3085DE">fas fa-pencil-alt</v-icon>
         </v-btn>
-        <v-btn text fab small class="mr-2">
+        <v-btn text fab small class="mr-2" @click="confirmDeleteArticle">
           <v-icon color="#3085DE">fas fa-trash-alt</v-icon>
         </v-btn>
       </v-layout>
@@ -28,6 +28,16 @@ import TimeAgo from 'vue2-timeago'
 import marked from "marked";
 import hljs from 'highlight.js';
 import Router from "../router/router";
+
+const headers = {
+  headers: {
+    Authorization: "Bearer",
+    "Access-Control-Allow-Origin": "*",
+    "access-token": localStorage.getItem("access-token"),
+    client: localStorage.getItem("client"),
+    uid: localStorage.getItem("uid")
+  }
+};
 
 export default {
   components: {
@@ -92,6 +102,21 @@ export default {
 
     moveToEditArticlePage(id) {
       Router.push(`/articles/${id}/edit`);
+    },
+
+    async confirmDeleteArticle() {
+      const result = confirm("この記事を削除してもよろしいですか？")
+      if (result) {
+        await axios
+          .delete(`/api/v1/articles/${this.article.id}`, headers)
+          .then(_response => {
+            Router.push("/")
+          })
+          .catch(e => {
+            // TODO: 適切な Error 表示
+            alert(e.response.statusText);
+          });
+      }
     }
   }
 }

--- a/app/javascript/components/Article.vue
+++ b/app/javascript/components/Article.vue
@@ -5,7 +5,7 @@
         <span class="user-name">@{{ article.user.name }}</span>
         <time-ago :refresh="60" :datetime="article.updated_at" locale="en" tooltip="top" long></time-ago>
         <v-spacer></v-spacer>
-        <v-btn text fab small class="mr-5">
+        <v-btn text fab small class="mr-5" @click="moveToEditArticlePage(article.id)">
           <v-icon color="#3085DE">fas fa-pencil-alt</v-icon>
         </v-btn>
         <v-btn text fab small class="mr-2">
@@ -27,6 +27,7 @@ import axios from "axios";
 import TimeAgo from 'vue2-timeago'
 import marked from "marked";
 import hljs from 'highlight.js';
+import Router from "../router/router";
 
 export default {
   components: {
@@ -69,6 +70,10 @@ export default {
       return function(text) {
         return marked(text);
       };
+    },
+
+    editAble() {
+      return localStorage.getItem("uid") === this.article.user.email
     }
   },
 
@@ -84,6 +89,10 @@ export default {
           alert(e.response.statusText);
         });
     },
+
+    moveToEditArticlePage(id) {
+      Router.push(`/articles/${id}/edit`);
+    }
   }
 }
 </script>

--- a/app/javascript/components/Article.vue
+++ b/app/javascript/components/Article.vue
@@ -4,6 +4,13 @@
       <v-layout xs-12 class="top-info-container">
         <span class="user-name">@{{ article.user.name }}</span>
         <time-ago :refresh="60" :datetime="article.updated_at" locale="en" tooltip="top" long></time-ago>
+        <v-spacer></v-spacer>
+        <v-btn text fab small class="mr-5">
+          <v-icon color="#3085DE">fas fa-pencil-alt</v-icon>
+        </v-btn>
+        <v-btn text fab small class="mr-2">
+          <v-icon color="#3085DE">fas fa-trash-alt</v-icon>
+        </v-btn>
       </v-layout>
       <v-layout>
         <h1 class="article-title">{{ article.title }}</h1>

--- a/app/javascript/components/EditArticle.vue
+++ b/app/javascript/components/EditArticle.vue
@@ -16,13 +16,13 @@
     </div>
     <div class="create_btn_area">
       <v-btn
-        @click="createArticle('published')"
+        @click="postArticle('published')"
         color="#3085DE"
         class="font-weight-bold white--text"
         >記事を投稿
       </v-btn>
       <v-btn
-        @click="createArticle('draft')"
+        @click="postArticle('draft')"
         color="#3085DE"
         class="font-weight-bold"
         outlined
@@ -49,6 +49,7 @@ const headers = {
 export default {
   data() {
     return {
+      id: "",
       title: "",
       body: "",
     }
@@ -84,23 +85,69 @@ export default {
   },
 
   methods: {
-    async createArticle(status) {
+    async postArticle(status) {
       const params = {
         title: this.title,
         body: this.body,
         status: status
       };
+
+      if (this.id) {
+        // update
+        await axios
+          .patch(`/api/v1/articles/${this.id}`, params, headers)
+          .then(_response => {
+            // TODO: 下書きの場合は下書き一覧ページに飛ばす
+            if (status == "published") {
+              Router.push("/");
+            } else {
+              Router.push("/articles/drafts");
+            }
+          })
+          .catch(e => {
+            // TODO: 適切な Error 表示
+            alert(e.response.data.errors);
+          });
+      } else {
+        // create
+        await axios
+          .post("/api/v1/articles", params, headers)
+          .then(_response => {
+            // TODO: 下書きの場合は下書き一覧ページに飛ばす
+            if (status == "published") {
+              Router.push("/");
+            } else {
+              Router.push("/articles/drafts");
+            }
+          })
+          .catch(e => {
+            // TODO: 適切な Error 表示
+            alert(e.response.data.errors);
+          });
+      }
+    },
+
+    async fetchArticle(id) {
       await axios
-        .post("/api/v1/articles", params, headers)
-        .then(_response => {
-          Router.push("/");
+        .get(`/api/v1/articles/${id}`)
+        .then(response => {
+          this.id = response.data.id;
+          this.title = response.data.title;
+          this.body = response.data.body;
         })
         .catch(e => {
           // TODO: 適切な Error 表示
-          alert(e.response.data.errors);
+          alert(e.response.statusText);
         });
     }
-  }
+  },
+
+  async mounted() {
+    if (this.$route.params.id) {
+      await this.fetchArticle(this.$route.params.id);
+    }
+  },
+
 }
 </script>
 

--- a/app/javascript/packs/hello_vue.js
+++ b/app/javascript/packs/hello_vue.js
@@ -15,6 +15,7 @@ import axios from "axios";
 import VueAxios from "vue-axios";
 import "vuetify/dist/vuetify.min.css";
 import "highlight.js/styles/monokai.css";
+import '@fortawesome/fontawesome-free/css/all.css'
 import Vuetify from "vuetify";
 Vue.use(Vuex);
 Vue.use(VueRouter);

--- a/app/javascript/router/router.js
+++ b/app/javascript/router/router.js
@@ -30,6 +30,10 @@ const router = new Router({
       component: EditArticle,
     },
     {
+      path: "/articles/:id/edit",
+      component: EditArticle
+    },
+    {
       path: "/articles/:id",
       component: Article,
       name: "article",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
   get "sign_up", to: "home#index"
   get "sign_in", to: "home#index"
   get "articles/new", to: "home#index"
+  get "articles/:id/edit", to: "homes#index"
   get "articles/:id", to: "home#index"
 
   namespace :api do

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "wonderful_editor",
   "private": true,
   "dependencies": {
+    "@fortawesome/fontawesome-free": "^5.14.0",
     "@rails/actioncable": "^6.0.0",
     "@rails/activestorage": "^6.0.0",
     "@rails/ujs": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1040,6 +1040,11 @@
   resolved "https://registry.yarnpkg.com/@csstools/convert-colors/-/convert-colors-1.4.0.tgz#ad495dc41b12e75d588c6db8b9834f08fa131eb7"
   integrity sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw==
 
+"@fortawesome/fontawesome-free@^5.14.0":
+  version "5.14.0"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-free/-/fontawesome-free-5.14.0.tgz#a371e91029ebf265015e64f81bfbf7d228c9681f"
+  integrity sha512-OfdMsF+ZQgdKHP9jUbmDcRrP0eX90XXrsXIdyjLbkmSBzmMXPABB8eobUJtivaupucYaByz6WNe1PI1JuYm3qA==
+
 "@rails/actioncable@^6.0.0":
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/@rails/actioncable/-/actioncable-6.0.3.tgz#722b4b639936129307ddbab3a390f6bcacf3e7bc"


### PR DESCRIPTION
## 概要
- 記事詳細ページに編集ボタンと削除ボタンを設置
  - 編集ボタンを押すと記事編集ページへ遷移して、前回の保存内容を表示

## 補足
icon は fontAwesome を使用