### PR TITLE
記事の下書きに関するフロントの実装

### DIFF
--- a/app/javascript/components/ArticleList.vue
+++ b/app/javascript/components/ArticleList.vue
@@ -1,22 +1,39 @@
 <template>
   <v-container class="mt-5">
-    <div>
+    <v-card  tile flat class="mx-auto py-7 px-5" max-width="800">
       <div v-for="article in articles" v-bind:key="article.id">
-        <v-card flat class="mb-5 pb-7" style="margin: 0 auto;" justify-center max-width="600" >
-          <v-card-title class="article-title">
-            <router-link :to="{ name: 'article', params: { id: article.id }}">{{ article.title }}</router-link>
-          </v-card-title>
-          <time-ago
-            class="ml-5"
-            :refresh="60"
-            :datetime="article.updated_at"
-            locale="en"
-            tooltip="right"
-            long
-          ></time-ago>
-        </v-card>
+        <v-list-item two-line>
+          <!-- 将来的に画像を配置したいので配置 -->
+          <template v-if="article.user.image">
+            <v-list-item-avatar>
+              <v-img :src="article.user.image"></v-img>
+            </v-list-item-avatar>
+          </template>
+          <template v-else>
+            <v-list-item-avatar size="50px" color="#3085DE">
+              <v-icon large color="#fff">fas fa-user</v-icon>
+            </v-list-item-avatar>
+          </template>
+
+          <v-list-item-content>
+            <v-list-item-title class="article-title">
+              <router-link :to="{ name: 'article', params: { id: article.id }}">{{ article.title }}</router-link>
+            </v-list-item-title>
+            <v-list-item-subtitle>
+              by {{article.user.name}}
+              <time-ago
+                :refresh="60"
+                :datetime="article.updated_at"
+                locale="en"
+                tooltip="right"
+                long
+              ></time-ago>
+            </v-list-item-subtitle>
+          </v-list-item-content>
+        </v-list-item>
+        <v-divider></v-divider>
       </div>
-    </div>
+    </v-card>
   </v-container>
 </template>
 

--- a/app/javascript/components/DraftArticlesContainer.vue
+++ b/app/javascript/components/DraftArticlesContainer.vue
@@ -1,0 +1,101 @@
+<template>
+  <v-container class="mt-5">
+    <v-card  tile flat class="mx-auto py-7 px-5" max-width="800">
+      <h2 class="ml-3 mb-3">下書き一覧</h2>
+      <div v-for="article in articles" v-bind:key="article.id">
+        <v-list-item two-line>
+          <!-- 将来的に画像を配置したいので配置 -->
+          <template v-if="article.user.image">
+            <v-list-item-avatar>
+              <v-img :src="article.user.image"></v-img>
+            </v-list-item-avatar>
+          </template>
+          <template v-else>
+            <v-list-item-avatar size="50px" color="#3085DE">
+              <v-icon large color="#fff">fas fa-user</v-icon>
+            </v-list-item-avatar>
+          </template>
+
+          <v-list-item-content>
+            <v-list-item-title class="article-title">
+              <a @click="moveToEditPage(article.id)">{{ article.title }}</a>
+            </v-list-item-title>
+            <v-list-item-subtitle>
+              by {{article.user.name}}
+              <time-ago
+                :refresh="60"
+                :datetime="article.updated_at"
+                locale="en"
+                tooltip="right"
+                long
+              ></time-ago>
+            </v-list-item-subtitle>
+          </v-list-item-content>
+        </v-list-item>
+        <v-divider></v-divider>
+      </div>
+    </v-card>
+  </v-container>
+</template>
+
+<script>
+import axios from "axios";
+import TimeAgo from 'vue2-timeago'
+import Router from "../router/router";
+
+const headers = {
+  headers: {
+    Authorization: "Bearer",
+    "Access-Control-Allow-Origin": "*",
+    "access-token": localStorage.getItem("access-token"),
+    client: localStorage.getItem("client"),
+    uid: localStorage.getItem("uid")
+  }
+};
+
+export default {
+  components: {
+    TimeAgo,
+  },
+
+  data() {
+    return {
+      articles: []
+    }
+  },
+
+  mounted() {
+    this.fetchArticles();
+  },
+
+  methods: {
+    async fetchArticles() {
+      await axios.get("/api/v1/articles/drafts", headers).then(response => {
+        response.data.map((article) => {
+          this.articles.push(article);
+        });
+      });
+    },
+
+    moveToEditPage(id) {
+      Router.push(`/articles/drafts/${id}/edit`);
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.article-title {
+  a {
+    color: #000;
+    font-weight: bold;
+    text-decoration: none;
+  }
+  a:hover {
+    text-decoration: underline;
+  }
+  a:visited {
+    color: #777;
+  }
+}
+</style>

--- a/app/javascript/components/EditDraftArticleContainer.vue
+++ b/app/javascript/components/EditDraftArticleContainer.vue
@@ -1,0 +1,203 @@
+<template>
+  <form class="article-form">
+    <v-text-field outlined single-line v-model="title" name="title" placeholder="タイトル" class="title-form"></v-text-field>
+    <div class="edit-area">
+      <v-textarea
+        outlined
+        no-resize
+        hide-details
+        height="100%"
+        v-model="body"
+        name="body"
+        placeholder="Markdown で記述することができます"
+        class="body-form"
+      ></v-textarea>
+      <div v-html="compiledMarkdown(this.body)" class="preview">a</div>
+    </div>
+    <div class="create_btn_area">
+      <v-btn
+        @click="postArticle('published')"
+        color="#3085DE"
+        class="font-weight-bold white--text"
+        >記事を投稿
+      </v-btn>
+      <v-btn
+        @click="postArticle('draft')"
+        color="#3085DE"
+        class="font-weight-bold"
+        outlined
+        >下書き投稿
+      </v-btn>
+    </div>
+  </form>
+</template>
+
+<script>
+import axios from "axios";
+import Router from "../router/router";
+import marked from "marked";
+import hljs from "highlight.js";
+
+const headers = {
+  headers: {
+    access_token: localStorage.getItem("access-token"),
+    client: localStorage.getItem("client"),
+    uid: localStorage.getItem("uid")
+  }
+};
+
+export default {
+  data() {
+    return {
+      id: "",
+      title: "",
+      body: "",
+    }
+  },
+
+  async created(){
+    const renderer = new marked.Renderer();
+    let data = "";
+    renderer.code = function(code, lang) {
+      const _lang = lang.split(".").pop();
+      try {
+        data = hljs.highlight(_lang, code, true).value;
+      } catch (e) {
+        data = hljs.highlightAuto(code).value;
+      }
+      return `<pre><code class="hljs"> ${data} </code></pre>`;
+    };
+
+    marked.setOptions({
+      renderer: renderer,
+      tables: true,
+      sanitize: true,
+      langPrefix: ""
+    });
+  },
+
+  computed: {
+    compiledMarkdown() {
+      return function(text) {
+        return marked(text);
+      };
+    }
+  },
+
+  methods: {
+    async postArticle(status) {
+      const params = {
+        title: this.title,
+        body: this.body,
+        status: status
+      };
+
+      if (this.id) {
+        // update
+        await axios
+          .patch(`/api/v1/articles/${this.id}`, params, headers)
+          .then(_response => {
+            // TODO: 下書きの場合は下書き一覧ページに飛ばす
+            if (status == "published") {
+              Router.push("/");
+            } else {
+              Router.push("/articles/drafts");
+            }
+          })
+          .catch(e => {
+            // TODO: 適切な Error 表示
+            alert(e.response.data.errors);
+          });
+      } else {
+        // create
+        await axios
+          .post("/api/v1/articles", params, headers)
+          .then(_response => {
+            // TODO: 下書きの場合は下書き一覧ページに飛ばす
+            if (status == "published") {
+              Router.push("/");
+            } else {
+              Router.push("/articles/drafts");
+            }
+          })
+          .catch(e => {
+            // TODO: 適切な Error 表示
+            alert(e.response.data.errors);
+          });
+      }
+    },
+
+    async fetchArticle(id) {
+      await axios
+        .get(`/api/v1/articles/drafts/${id}`, headers)
+        .then(response => {
+          this.id = response.data.id;
+          this.title = response.data.title;
+          this.body = response.data.body;
+        })
+        .catch(e => {
+          // TODO: 適切な Error 表示
+          alert(e.response.statusText);
+        });
+    }
+  },
+
+  async mounted() {
+    if (this.$route.params.id) {
+      await this.fetchArticle(this.$route.params.id);
+    }
+  },
+
+}
+</script>
+
+<style lang="scss" scoped>
+.article-form {
+  margin: 5px;
+  height: calc(100% - 64px - 10px);
+  display: flex;
+  flex-flow: column;
+  width: 100%;
+}
+
+.title-form {
+  flex: none;
+  background: #fff;
+}
+
+.edit-area {
+  height: 100%;
+  display: flex;
+  overflow: hidden;
+  background: #fff;
+  margin-bottom: 10px;
+}
+
+.preview {
+  width: 50%;
+  padding: 12px;
+  // margin-bottom: 8px;
+  border: 1px solid rgba(0,0,0,.42);
+  border-radius: 4px;
+  border-left: none;
+  overflow: auto;
+}
+</style>
+
+<style lang="scss">
+.body-form > .v-input__control {
+  height: 100%;
+}
+
+.create_btn_area {
+  text-align: right;
+}
+
+.v-text-field .v-text-field__details {
+  display: none;
+}
+
+.input__slot {
+  background: #fff;
+}
+</style>

--- a/app/javascript/components/layout/Header.vue
+++ b/app/javascript/components/layout/Header.vue
@@ -10,7 +10,21 @@
       <router-link to="/articles/new" class="header-link">
         <v-btn text class="post font-weight-bold">投稿する</v-btn>
       </router-link>
-      <v-btn text @click="logout" class="white--text font-weight-bold">ログアウト</v-btn>
+      <v-menu bottom left min-width="120">
+        <template v-slot:activator="{ on }">
+          <v-btn dark icon v-on="on">
+            <v-icon>fas fa-ellipsis-v</v-icon>
+          </v-btn>
+        </template>
+
+        <v-list>
+          <v-list-item link v-for="(menu, i) in menus" :key="i" @click="undefined">
+            <v-list-item-content>
+              <v-list-item-title @click="menu.click">{{ menu.title }}</v-list-item-title>
+            </v-list-item-content>
+          </v-list-item>
+        </v-list>
+      </v-menu>
     </template>
     <template v-else>
       <router-link to="/sign_up" class="header-link">
@@ -40,9 +54,31 @@ const headers = {
 };
 
 export default {
-    data() {
+  data() {
     return {
-      isLoggedIn: !!localStorage.getItem("access-token")
+      isLoggedIn: !!localStorage.getItem("access-token"),
+
+      menus: [
+        {
+          title: "マイページ",
+          click: () => {
+            this.moveToMyPage();
+          }
+        },
+        {
+          title: "下書き一覧",
+          click: () => {
+            this.moveToDrafts();
+          }
+        },
+        {
+          title: "ログアウト",
+          click: () => {
+            this.logout();
+          }
+        }
+      ]
+
     }
   },
 
@@ -67,6 +103,14 @@ export default {
       Router.push("/");
       // TODO: Vuex でログイン状態を管理するようになったら消す
       window.location.reload();
+    },
+
+    moveToMyPage() {
+      alert("マイページへ移動");
+    },
+
+    moveToDrafts() {
+      Router.push("/articles/drafts");
     }
   }
 }

--- a/app/javascript/router/router.js
+++ b/app/javascript/router/router.js
@@ -5,6 +5,8 @@ import Article from "../components/Article.vue";
 import Registration from "../components/Registration.vue";
 import Login from "../components/Login.vue";
 import EditArticle from "../components/EditArticle.vue";
+import DraftArticlesContainer from "../components/DraftArticlesContainer.vue";
+import EditDraftArticleContainer from "../components/EditDraftArticleContainer.vue";
 
 Vue.use(Router);
 
@@ -30,8 +32,17 @@ const router = new Router({
       component: EditArticle,
     },
     {
+      path: "/articles/drafts",
+      component: DraftArticlesContainer
+    },
+    {
       path: "/articles/:id/edit",
       component: EditArticle
+    },
+    {
+      path:
+      "/articles/drafts/:id/edit",
+      component: EditDraftArticleContainer
     },
     {
       path: "/articles/:id",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,9 @@ Rails.application.routes.draw do
   get "sign_up", to: "home#index"
   get "sign_in", to: "home#index"
   get "articles/new", to: "home#index"
-  get "articles/:id/edit", to: "homes#index"
+  get "articles/draft", to: "home#index"
+  get "articles/drafts/:id/edit", to: "home#index"
+  get "articles/:id/edit", to: "home#index"
   get "articles/:id", to: "home#index"
 
   namespace :api do


### PR DESCRIPTION
## 概要
- 記事の下書きに関するフロントの実装
  - 下書き記事の一覧ページ
  - 下書き記事の編集ページ
  - ヘッダーに下書き一覧ページへのリンクを追加

## 補足
- トップページの記事一覧のデザインを修正
（下書き記事一覧にも同様にしたかった為、このタイミングで修正した）